### PR TITLE
Cardboard HMD: Provide skewed FOVs to simulate a "focal distance"

### DIFF
--- a/build/webvr-polyfill.js
+++ b/build/webvr-polyfill.js
@@ -60,20 +60,27 @@ var HMDVRDevice = require('./base.js').HMDVRDevice;
 
 // Constants from vrtoolkit: https://github.com/googlesamples/cardboard-java.
 var INTERPUPILLARY_DISTANCE = 0.06;
-var DEFAULT_MAX_FOV_LEFT_RIGHT = 40;
-var DEFAULT_MAX_FOV_BOTTOM = 40;
-var DEFAULT_MAX_FOV_TOP = 40;
+var DEFAULT_MAX_FOV_TOP = 53.09438705444336;
+var DEFAULT_MAX_FOV_BOTTOM = 53.09438705444336;
+var DEFAULT_MAX_FOV_OUTER = 46.63209533691406;
+var DEFAULT_MAX_FOV_INNER = 47.52769470214844;
 
 /**
  * The HMD itself, providing rendering parameters.
  */
 function CardboardHMDVRDevice() {
   // From com/google/vrtoolkit/cardboard/FieldOfView.java.
-  this.fov = {
+  this.fovLeft = {
     upDegrees: DEFAULT_MAX_FOV_TOP,
     downDegrees: DEFAULT_MAX_FOV_BOTTOM,
-    leftDegrees: DEFAULT_MAX_FOV_LEFT_RIGHT,
-    rightDegrees: DEFAULT_MAX_FOV_LEFT_RIGHT
+    leftDegrees: DEFAULT_MAX_FOV_OUTER,
+    rightDegrees: DEFAULT_MAX_FOV_INNER
+  };
+  this.fovRight = {
+    upDegrees: DEFAULT_MAX_FOV_TOP,
+    downDegrees: DEFAULT_MAX_FOV_BOTTOM,
+    leftDegrees: DEFAULT_MAX_FOV_INNER,
+    rightDegrees: DEFAULT_MAX_FOV_OUTER
   };
   // Set display constants.
   this.eyeTranslationLeft = {
@@ -90,17 +97,19 @@ function CardboardHMDVRDevice() {
 CardboardHMDVRDevice.prototype = new HMDVRDevice();
 
 CardboardHMDVRDevice.prototype.getEyeParameters = function(whichEye) {
-  var eyeTranslation;
+  var eyeTranslation, fov;
   if (whichEye == 'left') {
     eyeTranslation = this.eyeTranslationLeft;
+    fov = this.fovLeft;
   } else if (whichEye == 'right') {
     eyeTranslation = this.eyeTranslationRight;
+    fov = this.fovRight;
   } else {
     console.error('Invalid eye provided: %s', whichEye);
     return null;
   }
   return {
-    recommendedFieldOfView: this.fov,
+    recommendedFieldOfView: fov,
     eyeTranslation: eyeTranslation
   };
 };

--- a/build/webvr-polyfill.js
+++ b/build/webvr-polyfill.js
@@ -58,8 +58,7 @@ module.exports.PositionSensorVRDevice = PositionSensorVRDevice;
  */
 var HMDVRDevice = require('./base.js').HMDVRDevice;
 
-// Constants from vrtoolkit: https://github.com/googlesamples/cardboard-java.
-var INTERPUPILLARY_DISTANCE = 0.06;
+var INTERPUPILLARY_DISTANCE = 0.064;
 var DEFAULT_MAX_FOV_TOP = 53.09438705444336;
 var DEFAULT_MAX_FOV_BOTTOM = 53.09438705444336;
 var DEFAULT_MAX_FOV_OUTER = 46.63209533691406;

--- a/src/cardboard-hmd-vr-device.js
+++ b/src/cardboard-hmd-vr-device.js
@@ -16,20 +16,27 @@ var HMDVRDevice = require('./base.js').HMDVRDevice;
 
 // Constants from vrtoolkit: https://github.com/googlesamples/cardboard-java.
 var INTERPUPILLARY_DISTANCE = 0.06;
-var DEFAULT_MAX_FOV_LEFT_RIGHT = 40;
-var DEFAULT_MAX_FOV_BOTTOM = 40;
-var DEFAULT_MAX_FOV_TOP = 40;
+var DEFAULT_MAX_FOV_TOP = 53.09438705444336;
+var DEFAULT_MAX_FOV_BOTTOM = 53.09438705444336;
+var DEFAULT_MAX_FOV_OUTER = 46.63209533691406;
+var DEFAULT_MAX_FOV_INNER = 47.52769470214844;
 
 /**
  * The HMD itself, providing rendering parameters.
  */
 function CardboardHMDVRDevice() {
   // From com/google/vrtoolkit/cardboard/FieldOfView.java.
-  this.fov = {
+  this.fovLeft = {
     upDegrees: DEFAULT_MAX_FOV_TOP,
     downDegrees: DEFAULT_MAX_FOV_BOTTOM,
-    leftDegrees: DEFAULT_MAX_FOV_LEFT_RIGHT,
-    rightDegrees: DEFAULT_MAX_FOV_LEFT_RIGHT
+    leftDegrees: DEFAULT_MAX_FOV_OUTER,
+    rightDegrees: DEFAULT_MAX_FOV_INNER
+  };
+  this.fovRight = {
+    upDegrees: DEFAULT_MAX_FOV_TOP,
+    downDegrees: DEFAULT_MAX_FOV_BOTTOM,
+    leftDegrees: DEFAULT_MAX_FOV_INNER,
+    rightDegrees: DEFAULT_MAX_FOV_OUTER
   };
   // Set display constants.
   this.eyeTranslationLeft = {
@@ -46,17 +53,19 @@ function CardboardHMDVRDevice() {
 CardboardHMDVRDevice.prototype = new HMDVRDevice();
 
 CardboardHMDVRDevice.prototype.getEyeParameters = function(whichEye) {
-  var eyeTranslation;
+  var eyeTranslation, fov;
   if (whichEye == 'left') {
     eyeTranslation = this.eyeTranslationLeft;
+    fov = this.fovLeft;
   } else if (whichEye == 'right') {
     eyeTranslation = this.eyeTranslationRight;
+    fov = this.fovRight;
   } else {
     console.error('Invalid eye provided: %s', whichEye);
     return null;
   }
   return {
-    recommendedFieldOfView: this.fov,
+    recommendedFieldOfView: fov,
     eyeTranslation: eyeTranslation
   };
 };

--- a/src/cardboard-hmd-vr-device.js
+++ b/src/cardboard-hmd-vr-device.js
@@ -14,8 +14,7 @@
  */
 var HMDVRDevice = require('./base.js').HMDVRDevice;
 
-// Constants from vrtoolkit: https://github.com/googlesamples/cardboard-java.
-var INTERPUPILLARY_DISTANCE = 0.06;
+var INTERPUPILLARY_DISTANCE = 0.064;
 var DEFAULT_MAX_FOV_TOP = 53.09438705444336;
 var DEFAULT_MAX_FOV_BOTTOM = 53.09438705444336;
 var DEFAULT_MAX_FOV_OUTER = 46.63209533691406;


### PR DESCRIPTION
Via https://github.com/mrdoob/three.js/pull/7036#issuecomment-135509274

I understand the FOVs for each eye should be slightly skewed inwards to simulate a focal distance.
See for example here: http://paulbourke.net/stereographics/stereorender/

The values I'm using are the ones provided by the experimental Chrome WebVR builds.
They result in a focal distance of ~1.90.

I've also changed the interpupillary distance to the average [according to Wikipedia](https://en.wikipedia.org/wiki/Interpupillary_distance).

wdyt?
cc @tschw