### PR TITLE
Derequires build to be friendly with browserified projects

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 default:
 	mkdir -p build
-	browserify src/main.js > build/webvr-polyfill.js
+	browserify src/main.js | derequire > build/webvr-polyfill.js
 	cp build/webvr-polyfill.js ../webvr-boilerplate/bower_components/webvr-polyfill/build/webvr-polyfill.js
 
 watch:


### PR DESCRIPTION
Thanks for your hard work. Your library has been very useful. I'm running into a problem when using your module within a project that also uses browserify. It's unfortunate that browserified dependencies don't play well within a browserified project! The parser looks for the require calls in all the modules (including external dependencies) and tries to resolve them. We end up with a bunch of `Cannot find module XXX.js` errors. That's an old issue that as far as I know hasn't been solved yet. There's a discussion going here: https://github.com/substack/node-browserify/pull/1151

On your side, you can run your build through [derequire](https://www.npmjs.com/package/derequire) to make it easier to consume. [derequire](https://www.npmjs.com/package/derequire) renames the `require` calls to `_dereq_` so browserify ignores them. No functionality is affected. The only downside is that your build file will take a tiny bit longer to generate.