### PR TITLE
Flag to disable MouseKeyboardPositionSensorVRDevice

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,4 +50,6 @@ are supported:
       //PREDICTION_TIME_S: 0.050, // Default: 0.050s.
       // Flag to disable touch panner. In case you have your own touch controls
       //TOUCH_PANNER_DISABLED: true, // Default: false.
+      // To disable keyboard and mouse controls. In case you implement your own
+      //MOUSE_KEYBOARD_CONTROLS_DISABLED: true // Default: false
     }

--- a/src/webvr-polyfill.js
+++ b/src/webvr-polyfill.js
@@ -46,7 +46,9 @@ WebVRPolyfill.prototype.enablePolyfill = function() {
     //this.devices.push(new OrientationPositionSensorVRDevice());
     this.devices.push(new FusionPositionSensorVRDevice());
   } else {
-    this.devices.push(new MouseKeyboardPositionSensorVRDevice());
+    if (!WebVRConfig.MOUSE_KEYBOARD_CONTROLS_DISABLED) {
+      this.devices.push(new MouseKeyboardPositionSensorVRDevice());
+    }
     // Uncomment to add positional tracking via webcam.
     //this.devices.push(new WebcamPositionSensorVRDevice());
   }


### PR DESCRIPTION
This is similar to my previous https://github.com/borismus/webvr-polyfill/pull/18
I have my own mouse and keyboard controls and ```MouseKeyboardPositionSensorVRDevice``` is conflicting with them. I would like to have the option to disable them. If you want to handle this differently let me know and I will update the PR.