### PR TITLE
Taking a stab at fixing some iOS issues.

### DIFF
--- a/build/webvr-polyfill.js
+++ b/build/webvr-polyfill.js
@@ -982,6 +982,7 @@ var nextDisplayId = 1000;
  * The base class for all VR displays.
  */
 function VRDisplay() {
+  this.isPolyfilled = true;
   this.displayId = nextDisplayId++;
   this.displayName = 'webvr-polyfill displayName';
 
@@ -1252,6 +1253,7 @@ VRDisplay.prototype.getEyeParameters = function(whichEye) {
  * The base class for all VR devices. (Deprecated)
  */
 function VRDevice() {
+  this.isPolyfilled = true;
   this.hardwareUnitId = 'webvr-polyfill hardwareUnitId';
   this.deviceId = 'webvr-polyfill deviceId';
   this.deviceName = 'webvr-polyfill deviceName';
@@ -1344,8 +1346,11 @@ function CardboardDistorter(gl) {
   this.realColorMask = gl.colorMask;
   this.realClearColor = gl.clearColor;
   this.realViewport = gl.viewport;
-  this.realCanvasWidth = Object.getOwnPropertyDescriptor(gl.canvas.__proto__, 'width');
-  this.realCanvasHeight = Object.getOwnPropertyDescriptor(gl.canvas.__proto__, 'height');
+
+  if (!Util.isIOS()) {
+    this.realCanvasWidth = Object.getOwnPropertyDescriptor(gl.canvas.__proto__, 'width');
+    this.realCanvasHeight = Object.getOwnPropertyDescriptor(gl.canvas.__proto__, 'height');
+  }
 
   this.isPatched = false;
 
@@ -1509,32 +1514,34 @@ CardboardDistorter.prototype.patch = function() {
   var canvas = this.gl.canvas;
   var gl = this.gl;
 
-  canvas.width = Util.getScreenWidth() * this.bufferScale;
-  canvas.height = Util.getScreenHeight() * this.bufferScale;
+  if (!Util.isIOS()) {
+    canvas.width = Util.getScreenWidth() * this.bufferScale;
+    canvas.height = Util.getScreenHeight() * this.bufferScale;
 
-  Object.defineProperty(canvas, 'width', {
-    configurable: true,
-    enumerable: true,
-    get: function() {
-      return self.bufferWidth;
-    },
-    set: function(value) {
-      self.bufferWidth = value;
-      self.onResize();
-    }
-  });
+    Object.defineProperty(canvas, 'width', {
+      configurable: true,
+      enumerable: true,
+      get: function() {
+        return self.bufferWidth;
+      },
+      set: function(value) {
+        self.bufferWidth = value;
+        self.onResize();
+      }
+    });
 
-  Object.defineProperty(canvas, 'height', {
-    configurable: true,
-    enumerable: true,
-    get: function() {
-      return self.bufferHeight;
-    },
-    set: function(value) {
-      self.bufferHeight = value;
-      self.onResize();
-    }
-  });
+    Object.defineProperty(canvas, 'height', {
+      configurable: true,
+      enumerable: true,
+      get: function() {
+        return self.bufferHeight;
+      },
+      set: function(value) {
+        self.bufferHeight = value;
+        self.onResize();
+      }
+    });
+  }
 
   this.lastBoundFramebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING);
 
@@ -1615,8 +1622,10 @@ CardboardDistorter.prototype.unpatch = function() {
   var gl = this.gl;
   var canvas = this.gl.canvas;
 
-  Object.defineProperty(canvas, 'width', this.realCanvasWidth);
-  Object.defineProperty(canvas, 'height', this.realCanvasHeight);
+  if (!Util.isIOS()) {
+    Object.defineProperty(canvas, 'width', this.realCanvasWidth);
+    Object.defineProperty(canvas, 'height', this.realCanvasHeight);
+  }
   canvas.width = this.bufferWidth;
   canvas.height = this.bufferHeight;
 
@@ -1690,7 +1699,7 @@ CardboardDistorter.prototype.submitFrame = function() {
 
     // If the backbuffer has an alpha channel clear every frame so the page
     // doesn't show through.
-    if (self.ctxAttribs.alpha) {
+    if (self.ctxAttribs.alpha || Util.isIOS()) {
       self.realClearColor.call(gl, 0, 0, 0, 1);
       gl.clear(gl.COLOR_BUFFER_BIT);
     }
@@ -1743,6 +1752,19 @@ CardboardDistorter.prototype.submitFrame = function() {
       self.realClearColor.apply(gl, self.clearColor);
     }
   });
+
+  // Workaround for the fact that Safari doesn't allow us to patch the canvas
+  // width and height correctly. After each submit frame check to see what the
+  // real backbuffer size has been set to and resize the fake backbuffer size
+  // to match.
+  if (Util.isIOS()) {
+    var canvas = gl.canvas;
+    if (canvas.width != self.bufferWidth || canvas.height != self.bufferHeight) {
+      self.bufferWidth = canvas.width;
+      self.bufferHeight = canvas.height;
+      self.onResize();
+    }
+  }
 };
 
 /**
@@ -2093,8 +2115,6 @@ CardboardUI.prototype.onResize = function() {
     // Buffer data
     gl.bindBuffer(gl.ARRAY_BUFFER, self.vertexBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(vertices), gl.STATIC_DRAW);
-
-
   });
 };
 
@@ -7448,22 +7468,27 @@ Util.lerp = function(a, b, t) {
   return a + ((b - a) * t);
 };
 
-Util.pingPong = function(t, length) {
-  if (t < 0) t = -t;
+Util.isIOS = (function() {
+  var isIOS = /iPad|iPhone|iPod/.test(navigator.platform);
+  return function() {
+    return isIOS;
+  };
+})();
 
-  var mult = Math.floor(t / length);
-  var mod = t - (length * mult);
-  return mult % 2 ? length - mod : mod;
-};
+Util.isSafari = (function() {
+  var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  return function() {
+    return isSafari;
+  };
+})();
 
-Util.isIOS = function() {
-  return /iPad|iPhone|iPod/.test(navigator.platform);
-};
-
-Util.isFirefoxAndroid = function() {
-  return navigator.userAgent.indexOf('Firefox') !== -1 &&
+Util.isFirefoxAndroid = (function() {
+  var isFirefoxAndroid = navigator.userAgent.indexOf('Firefox') !== -1 &&
       navigator.userAgent.indexOf('Android') !== -1;
-};
+  return function() {
+    return isFirefoxAndroid;
+  };
+})();
 
 Util.isLandscapeMode = function() {
   return (window.orientation == 90 || window.orientation == -90);

--- a/src/cardboard-distorter.js
+++ b/src/cardboard-distorter.js
@@ -65,8 +65,11 @@ function CardboardDistorter(gl) {
   this.realColorMask = gl.colorMask;
   this.realClearColor = gl.clearColor;
   this.realViewport = gl.viewport;
-  this.realCanvasWidth = Object.getOwnPropertyDescriptor(gl.canvas.__proto__, 'width');
-  this.realCanvasHeight = Object.getOwnPropertyDescriptor(gl.canvas.__proto__, 'height');
+
+  if (!Util.isIOS()) {
+    this.realCanvasWidth = Object.getOwnPropertyDescriptor(gl.canvas.__proto__, 'width');
+    this.realCanvasHeight = Object.getOwnPropertyDescriptor(gl.canvas.__proto__, 'height');
+  }
 
   this.isPatched = false;
 
@@ -230,32 +233,34 @@ CardboardDistorter.prototype.patch = function() {
   var canvas = this.gl.canvas;
   var gl = this.gl;
 
-  canvas.width = Util.getScreenWidth() * this.bufferScale;
-  canvas.height = Util.getScreenHeight() * this.bufferScale;
+  if (!Util.isIOS()) {
+    canvas.width = Util.getScreenWidth() * this.bufferScale;
+    canvas.height = Util.getScreenHeight() * this.bufferScale;
 
-  Object.defineProperty(canvas, 'width', {
-    configurable: true,
-    enumerable: true,
-    get: function() {
-      return self.bufferWidth;
-    },
-    set: function(value) {
-      self.bufferWidth = value;
-      self.onResize();
-    }
-  });
+    Object.defineProperty(canvas, 'width', {
+      configurable: true,
+      enumerable: true,
+      get: function() {
+        return self.bufferWidth;
+      },
+      set: function(value) {
+        self.bufferWidth = value;
+        self.onResize();
+      }
+    });
 
-  Object.defineProperty(canvas, 'height', {
-    configurable: true,
-    enumerable: true,
-    get: function() {
-      return self.bufferHeight;
-    },
-    set: function(value) {
-      self.bufferHeight = value;
-      self.onResize();
-    }
-  });
+    Object.defineProperty(canvas, 'height', {
+      configurable: true,
+      enumerable: true,
+      get: function() {
+        return self.bufferHeight;
+      },
+      set: function(value) {
+        self.bufferHeight = value;
+        self.onResize();
+      }
+    });
+  }
 
   this.lastBoundFramebuffer = gl.getParameter(gl.FRAMEBUFFER_BINDING);
 
@@ -336,8 +341,10 @@ CardboardDistorter.prototype.unpatch = function() {
   var gl = this.gl;
   var canvas = this.gl.canvas;
 
-  Object.defineProperty(canvas, 'width', this.realCanvasWidth);
-  Object.defineProperty(canvas, 'height', this.realCanvasHeight);
+  if (!Util.isIOS()) {
+    Object.defineProperty(canvas, 'width', this.realCanvasWidth);
+    Object.defineProperty(canvas, 'height', this.realCanvasHeight);
+  }
   canvas.width = this.bufferWidth;
   canvas.height = this.bufferHeight;
 
@@ -411,7 +418,7 @@ CardboardDistorter.prototype.submitFrame = function() {
 
     // If the backbuffer has an alpha channel clear every frame so the page
     // doesn't show through.
-    if (self.ctxAttribs.alpha) {
+    if (self.ctxAttribs.alpha || Util.isIOS()) {
       self.realClearColor.call(gl, 0, 0, 0, 1);
       gl.clear(gl.COLOR_BUFFER_BIT);
     }
@@ -464,6 +471,19 @@ CardboardDistorter.prototype.submitFrame = function() {
       self.realClearColor.apply(gl, self.clearColor);
     }
   });
+
+  // Workaround for the fact that Safari doesn't allow us to patch the canvas
+  // width and height correctly. After each submit frame check to see what the
+  // real backbuffer size has been set to and resize the fake backbuffer size
+  // to match.
+  if (Util.isIOS()) {
+    var canvas = gl.canvas;
+    if (canvas.width != self.bufferWidth || canvas.height != self.bufferHeight) {
+      self.bufferWidth = canvas.width;
+      self.bufferHeight = canvas.height;
+      self.onResize();
+    }
+  }
 };
 
 /**

--- a/src/cardboard-ui.js
+++ b/src/cardboard-ui.js
@@ -218,8 +218,6 @@ CardboardUI.prototype.onResize = function() {
     // Buffer data
     gl.bindBuffer(gl.ARRAY_BUFFER, self.vertexBuffer);
     gl.bufferData(gl.ARRAY_BUFFER, new Float32Array(vertices), gl.STATIC_DRAW);
-
-
   });
 };
 

--- a/src/util.js
+++ b/src/util.js
@@ -29,22 +29,27 @@ Util.lerp = function(a, b, t) {
   return a + ((b - a) * t);
 };
 
-Util.pingPong = function(t, length) {
-  if (t < 0) t = -t;
+Util.isIOS = (function() {
+  var isIOS = /iPad|iPhone|iPod/.test(navigator.platform);
+  return function() {
+    return isIOS;
+  };
+})();
 
-  var mult = Math.floor(t / length);
-  var mod = t - (length * mult);
-  return mult % 2 ? length - mod : mod;
-};
+Util.isSafari = (function() {
+  var isSafari = /^((?!chrome|android).)*safari/i.test(navigator.userAgent);
+  return function() {
+    return isSafari;
+  };
+})();
 
-Util.isIOS = function() {
-  return /iPad|iPhone|iPod/.test(navigator.platform);
-};
-
-Util.isFirefoxAndroid = function() {
-  return navigator.userAgent.indexOf('Firefox') !== -1 &&
+Util.isFirefoxAndroid = (function() {
+  var isFirefoxAndroid = navigator.userAgent.indexOf('Firefox') !== -1 &&
       navigator.userAgent.indexOf('Android') !== -1;
-};
+  return function() {
+    return isFirefoxAndroid;
+  };
+})();
 
 Util.isLandscapeMode = function() {
   return (window.orientation == 90 || window.orientation == -90);


### PR DESCRIPTION
I don't have an iOS device with me to test this with, sadly, but I think it should avoid the problems we're seeing in Issue #46. (I was at least able to test it on desktop Safari.) It no longer patches the canvas width and height in Safari and instead checks the values each `submitFrame` and resizes the framebuffer when needed. This will cause some minor quality and perf issues but prevent larger correctness ones. Also forces the backbuffer to clear every `submitFrame`, which should prevent the white background we're seeing. I also took the liberty of doing a minor optimization to the `Util.is...` functions, since they're going to get called a lot more frequently now and their return value should never change.

*Please test this on an iOS device before merging!*