### PR TITLE
Fix typo that disables listening on cardboard UI clicks

### DIFF
--- a/build/webvr-polyfill.js
+++ b/build/webvr-polyfill.js
@@ -8,6 +8,9 @@ var currentQueue;
 var queueIndex = -1;
 
 function cleanUpNextTick() {
+    if (!draining || !currentQueue) {
+        return;
+    }
     draining = false;
     if (currentQueue.length) {
         queue = currentQueue.concat(queue);
@@ -2503,7 +2506,7 @@ CardboardVRDisplay.prototype.beginPresent_ = function() {
     }
   }
 
-  if (this.carboardUI_) {
+  if (this.cardboardUI_) {
     this.cardboardUI_.listen(function() {
       // Options clicked
       this.viewerSelector_.show(this.layer_.source.parentElement);

--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -133,7 +133,7 @@ CardboardVRDisplay.prototype.beginPresent_ = function() {
     }
   }
 
-  if (this.carboardUI_) {
+  if (this.cardboardUI_) {
     this.cardboardUI_.listen(function() {
       // Options clicked
       this.viewerSelector_.show(this.layer_.source.parentElement);


### PR DESCRIPTION
[This commit](https://github.com/borismus/webvr-polyfill/commit/dda3c4b51cda0e307b8c168a392bd7e4f423729d) introduced a typo that makes the cardboard UI not listen on clicks.