### PR TITLE
fix orientation.lock() error handling

### DIFF
--- a/src/base.js
+++ b/src/base.js
@@ -188,7 +188,9 @@ VRDisplay.prototype.requestPresent = function(layers) {
         self.isPresenting = (fullscreenElement === actualFullscreenElement);
         if (self.isPresenting) {
           if (screen.orientation && screen.orientation.lock) {
-            screen.orientation.lock('landscape-primary');
+            screen.orientation.lock('landscape-primary').catch(function(error){
+                    console.error('screen.orientation.lock() failed due to', error.message)
+            });
           }
           self.waitingForPresent_ = false;
           self.beginPresent_();


### PR DESCRIPTION
- if screen.orientation.lock() fails, catch the error. 

thus it doesnt trigger an exception in js console. 

im not sure it is a bug. But when i launch webvr-polyfill in chrome desktop and toggle 'device mode' in devtools, this exception is triggered everytime you goto to vr mode.