### PR TITLE
Add options to WebVRConfig for customize Cardboard viewer list

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,26 @@ WebVRConfig = {
   // Dirty bindings include: gl.FRAMEBUFFER_BINDING, gl.CURRENT_PROGRAM,
   // gl.ARRAY_BUFFER_BINDING, gl.ELEMENT_ARRAY_BUFFER_BINDING,
   // and gl.TEXTURE_BINDING_2D for texture unit 0.
-  DIRTY_SUBMIT_FRAME_BINDINGS: true // Default: false.
+  DIRTY_SUBMIT_FRAME_BINDINGS: true, // Default: false.
+
+  // Add additional Cardboard viewer options
+  // CardboardV1 and CardboardV2 are current built-in viewers
+  // generate parameters for unsupported viewer:
+  // https://vr.google.com/cardboard/viewerprofilegenerator/
+  CARDBOARD_VIEWERS: [
+  {
+    id: 'VRBox',
+    label: 'VR Box',
+    fov: 50,
+    interLensDistance: 0.061,
+    baselineLensDistance: 0.035,
+    screenLensDistance: 0.044,
+    distortionCoefficients: [0.1, 0.02]
+  }
+  ], // Default: []
+
+  // Default cardboard viewer
+  DEFAULT_CARDBOARD_VIEWER: 'CardboardV1' // Default: 'CardboardV1'
 }
 ```
 

--- a/src/device-info.js
+++ b/src/device-info.js
@@ -43,7 +43,9 @@ var DEFAULT_IOS = new Device({
 });
 
 
-var Viewers = {
+var Viewers = undefined;
+
+var DEFAULT_VIEWERS = {
   CardboardV1: new CardboardViewer({
     id: 'CardboardV1',
     label: 'Cardboard I/O 2014',
@@ -51,10 +53,7 @@ var Viewers = {
     interLensDistance: 0.060,
     baselineLensDistance: 0.035,
     screenLensDistance: 0.042,
-    distortionCoefficients: [0.441, 0.156],
-    inverseCoefficients: [-0.4410035, 0.42756155, -0.4804439, 0.5460139,
-      -0.58821183, 0.5733938, -0.48303202, 0.33299083, -0.17573841,
-      0.0651772, -0.01488963, 0.001559834]
+    distortionCoefficients: [0.441, 0.156]
   }),
   CardboardV2: new CardboardViewer({
     id: 'CardboardV2',
@@ -63,16 +62,10 @@ var Viewers = {
     interLensDistance: 0.064,
     baselineLensDistance: 0.035,
     screenLensDistance: 0.039,
-    distortionCoefficients: [0.34, 0.55],
-    inverseCoefficients: [-0.33836704, -0.18162185, 0.862655, -1.2462051,
-      1.0560602, -0.58208317, 0.21609078, -0.05444823, 0.009177956,
-      -9.904169E-4, 6.183535E-5, -1.6981803E-6]
+    distortionCoefficients: [0.34, 0.55]
   })
 };
 
-
-var DEFAULT_LEFT_CENTER = {x: 0.5, y: 0.5};
-var DEFAULT_RIGHT_CENTER = {x: 0.5, y: 0.5};
 
 /**
  * Manages information about the device and the viewer.
@@ -82,7 +75,7 @@ var DEFAULT_RIGHT_CENTER = {x: 0.5, y: 0.5};
  * params were found.
  */
 function DeviceInfo(deviceParams) {
-  this.viewer = Viewers.CardboardV2;
+  this.viewer = DEFAULT_VIEWERS.CardboardV2;
   this.updateDeviceParams(deviceParams);
   this.distortion = new Distortion(this.viewer.distortionCoefficients);
 }
@@ -355,11 +348,22 @@ function CardboardViewer(params) {
 
   // Distortion coefficients.
   this.distortionCoefficients = params.distortionCoefficients;
-  // Inverse distortion coefficients.
-  // TODO: Calculate these from distortionCoefficients in the future.
-  this.inverseCoefficients = params.inverseCoefficients;
 }
 
 // Export viewer information.
-DeviceInfo.Viewers = Viewers;
+Object.defineProperty(DeviceInfo, 'Viewers', {
+  configurable: true,
+  enumerable: true,
+  get: function() {
+    if (!Viewers) {
+      // generate viewer
+      Viewers = Util.extend(DEFAULT_VIEWERS,
+        WebVRConfig.CARDBOARD_VIEWERS.reduce(function(viewers, params) {
+          viewers[params.id] = new CardboardViewer(params);
+          return viewers;
+        }, {}));
+    }
+    return Viewers;
+  }
+});
 module.exports = DeviceInfo;

--- a/src/main.js
+++ b/src/main.js
@@ -63,7 +63,29 @@ window.WebVRConfig = Util.extend({
   // Dirty bindings include: gl.FRAMEBUFFER_BINDING, gl.CURRENT_PROGRAM,
   // gl.ARRAY_BUFFER_BINDING, gl.ELEMENT_ARRAY_BUFFER_BINDING,
   // and gl.TEXTURE_BINDING_2D for texture unit 0.
-  DIRTY_SUBMIT_FRAME_BINDINGS: false
+  DIRTY_SUBMIT_FRAME_BINDINGS: false,
+
+  // Add additional Cardboard viewer options
+  // CardboardV1 and CardboardV2 are current built-in viewers
+  // Viewer parameters example:
+  // ```
+  // {
+  //   id: 'CardboardV1',
+  //   label: 'Cardboard I/O 2014',
+  //   fov: 40,
+  //   interLensDistance: 0.060,
+  //   baselineLensDistance: 0.035,
+  //   screenLensDistance: 0.042,
+  //   distortionCoefficients: [0.441, 0.156]
+  // }
+  // ```
+  // generate parameters for unsupported viewer:
+  // https://vr.google.com/cardboard/viewerprofilegenerator/
+  CARDBOARD_VIEWERS: [],
+
+  // Default cardboard viewer
+  DEFAULT_CARDBOARD_VIEWER: 'CardboardV1'
+
 }, window.WebVRConfig);
 
 if (!window.WebVRConfig.DEFER_INITIALIZATION) {

--- a/src/viewer-selector.js
+++ b/src/viewer-selector.js
@@ -17,7 +17,6 @@ var Emitter = require('./emitter.js');
 var Util = require('./util.js');
 var DeviceInfo = require('./device-info.js');
 
-var DEFAULT_VIEWER = 'CardboardV1';
 var VIEWER_KEY = 'WEBVR_CARDBOARD_VIEWER';
 var CLASS_NAME = 'webvr-polyfill-viewer-selector';
 
@@ -30,7 +29,7 @@ function ViewerSelector() {
   // Try to load the selected key from local storage. If none exists, use the
   // default key.
   try {
-    this.selectedKey = localStorage.getItem(VIEWER_KEY) || DEFAULT_VIEWER;
+    this.selectedKey = localStorage.getItem(VIEWER_KEY) || WebVRConfig.DEFAULT_CARDBOARD_VIEWER;
   } catch (error) {
     console.error('Failed to load viewer profile: %s', error);
   }


### PR DESCRIPTION
It supports only CardboardV1 and V2 in the polyfill library, but there are many other Cardboard viewer devices out there. To make it configurable for client application, this pull request adds following viewer setting to `WebVRConfig`:
* CARDBOARD_VIEWERS: for adding more viewer options
* DEFAULT_CARDBOARD_VIEWER: id of the default viewer