### PR TITLE
Only listen to the fullscreen-events of one of the different vendor

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,25 @@ WebVRConfig = {
   // button in the CARDBOARD_UI
   BACKACTION_CALLBACK: function() {
     //some code
-  } // Default: undefined.
+  }, // Default: undefined.
+
+  // A list of additional viewers, if the two different CardboardViewers in
+  // the polyfill aren't enough. Can be choosen via the gear icon in the
+  // CARDBOARD_UI
+  ADDITIONAL_VIEWERS: [
+    {
+      id: 'BoboVRZ2',
+      label: 'Bobo VR Z2',
+      fov: 55,
+      interLensDistance: 0.066,
+      baselineLensDistance: 0.035,
+      screenLensDistance: 0.045,
+      distortionCoefficients: [0.15, 0.01],
+      inverseCoefficients: [-0.4410035, 0.42756155, -0.4804439, 0.5460139,
+        -0.58821183, 0.5733938, -0.48303202, 0.33299083, -0.17573841,
+        0.0651772, -0.01488963, 0.001559834]
+    }
+  ] // Default: undefined.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ WebVRConfig = {
   // button in the CARDBOARD_UI
   BACKACTION_CALLBACK: function() {
     //some code
-  }, // Default: undefined.
+  } // Default: undefined.
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,13 @@ WebVRConfig = {
   // Dirty bindings include: gl.FRAMEBUFFER_BINDING, gl.CURRENT_PROGRAM,
   // gl.ARRAY_BUFFER_BINDING, gl.ELEMENT_ARRAY_BUFFER_BINDING,
   // and gl.TEXTURE_BINDING_2D for texture unit 0.
-  DIRTY_SUBMIT_FRAME_BINDINGS: true // Default: false.
+  DIRTY_SUBMIT_FRAME_BINDINGS: true, // Default: false.
+
+  // A custom callback which will be called when the User triggers the back
+  // button in the CARDBOARD_UI
+  BACKACTION_CALLBACK: function() {
+    //some code
+  }, // Default: undefined.
 }
 ```
 

--- a/build/webvr-polyfill.js
+++ b/build/webvr-polyfill.js
@@ -1606,11 +1606,13 @@ CardboardVRDisplay.prototype.beginPresent_ = function() {
     }.bind(this), function(e) {
       // Back clicked.
 
-      // In case of a custom calllback defined by the user, trigger it
-      if (typeof WebVRConfig.BACKACTION_CALLBACK === 'function') {
-        WebVRConfig.BACKACTION_CALLBACK();
-      }
-      this.exitPresent();
+      this.exitPresent().then(function () {
+        // In case of a custom calllback defined by the user, trigger it
+        if (typeof WebVRConfig.BACKACTION_CALLBACK === 'function') {
+          WebVRConfig.BACKACTION_CALLBACK();
+        }
+      });
+
       e.stopPropagation();
       e.preventDefault();
     }.bind(this));

--- a/build/webvr-polyfill.js
+++ b/build/webvr-polyfill.js
@@ -1699,6 +1699,12 @@ CardboardVRDisplay.prototype.onResize_ = function(e) {
     // hide the URL bar unless content is bigger than the screen.
     // This will not be visible as long as the container element (e.g. body)
     // is set to 'overflow: hidden'.
+    var padding;
+    if (Util.isIOS()) {
+      padding = '0 10px 10px 0';
+    } else {
+      padding = '0';
+    }
     var cssProperties = [
       'position: absolute',
       'top: 0',
@@ -1707,7 +1713,7 @@ CardboardVRDisplay.prototype.onResize_ = function(e) {
       'height: ' + Math.min(screen.height, screen.width) + 'px',
       'border: 0',
       'margin: 0',
-      'padding: 0 10px 10px 0',
+      'padding:' + padding,
     ];
     gl.canvas.setAttribute('style', cssProperties.join('; ') + ';');
 

--- a/build/webvr-polyfill.js
+++ b/build/webvr-polyfill.js
@@ -416,17 +416,27 @@ VRDisplay.prototype.addFullscreenListeners_ = function(element, changeHandler, e
   this.fullscreenErrorHandler_ = errorHandler;
 
   if (changeHandler) {
-    element.addEventListener('fullscreenchange', changeHandler, false);
-    element.addEventListener('webkitfullscreenchange', changeHandler, false);
-    document.addEventListener('mozfullscreenchange', changeHandler, false);
-    element.addEventListener('msfullscreenchange', changeHandler, false);
+    if (document.fullscreenEnabled) {
+      element.addEventListener('fullscreenchange', changeHandler, false);
+    } else if (document.webkitFullscreenEnabled) {
+      element.addEventListener('webkitfullscreenchange', changeHandler, false);
+    } else if (document.mozFullScreenEnabled) {
+      document.addEventListener('mozfullscreenchange', changeHandler, false);
+    } else if (document.msFullscreenEnabled) {
+      element.addEventListener('msfullscreenchange', changeHandler, false);
+    }
   }
 
   if (errorHandler) {
-    element.addEventListener('fullscreenerror', errorHandler, false);
-    element.addEventListener('webkitfullscreenerror', errorHandler, false);
-    document.addEventListener('mozfullscreenerror', errorHandler, false);
-    element.addEventListener('msfullscreenerror', errorHandler, false);
+    if (document.fullscreenEnabled) {
+      element.addEventListener('fullscreenerror', errorHandler, false);
+    } else if (document.webkitFullscreenEnabled) {
+      element.addEventListener('webkitfullscreenerror', errorHandler, false);
+    } else if (document.mozFullScreenEnabled) {
+      document.addEventListener('mozfullscreenerror', errorHandler, false);
+    } else if (document.msFullscreenEnabled) {
+      element.addEventListener('msfullscreenerror', errorHandler, false);
+    }
   }
 };
 
@@ -1595,6 +1605,11 @@ CardboardVRDisplay.prototype.beginPresent_ = function() {
       e.preventDefault();
     }.bind(this), function(e) {
       // Back clicked.
+
+      // In case of a custom calllback defined by the user, trigger it
+      if (typeof WebVRConfig.BACKACTION_CALLBACK === 'function') {
+        WebVRConfig.BACKACTION_CALLBACK();
+      }
       this.exitPresent();
       e.stopPropagation();
       e.preventDefault();
@@ -1973,6 +1988,13 @@ var DEFAULT_RIGHT_CENTER = {x: 0.5, y: 0.5};
  * params were found.
  */
 function DeviceInfo(deviceParams) {
+  if (WebVRConfig.ADDITIONAL_VIEWERS instanceof Array) {
+    var newViewer;
+    for (var i = 0; i < WebVRConfig.ADDITIONAL_VIEWERS.length; i++) {
+      newViewer = WebVRConfig.ADDITIONAL_VIEWERS[i];
+      Viewers[newViewer.id] = new CardboardViewer(newViewer);
+    }
+  }
   this.viewer = Viewers.CardboardV2;
   this.updateDeviceParams(deviceParams);
   this.distortion = new Distortion(this.viewer.distortionCoefficients);

--- a/src/base.js
+++ b/src/base.js
@@ -330,17 +330,17 @@ VRDisplay.prototype.addFullscreenListeners_ = function(element, changeHandler, e
   this.fullscreenErrorHandler_ = errorHandler;
 
   if (changeHandler) {
-    element.addEventListener('fullscreenchange', changeHandler, false);
-    element.addEventListener('webkitfullscreenchange', changeHandler, false);
-    document.addEventListener('mozfullscreenchange', changeHandler, false);
-    element.addEventListener('msfullscreenchange', changeHandler, false);
+    if (document.fullscreenEnabled) element.addEventListener('fullscreenchange', changeHandler, false);
+	  else if (document.webkitFullscreenEnabled) element.addEventListener('webkitfullscreenchange', changeHandler, false);
+	  else if (document.mozFullscreenEnabled) document.addEventListener('mozfullscreenchange', changeHandler, false);
+	  else if (document.msFullscreenEnabled) element.addEventListener('msfullscreenchange', changeHandler, false);
   }
 
   if (errorHandler) {
-    element.addEventListener('fullscreenerror', errorHandler, false);
-    element.addEventListener('webkitfullscreenerror', errorHandler, false);
-    document.addEventListener('mozfullscreenerror', errorHandler, false);
-    element.addEventListener('msfullscreenerror', errorHandler, false);
+    if (document.fullscreenEnabled) element.addEventListener('fullscreenerror', errorHandler, false);
+	  else if (document.webkitFullscreenEnabled) element.addEventListener('webkitfullscreenerror', errorHandler, false);
+	  else if (document.mozFullscreenEnabled) document.addEventListener('mozfullscreenerror', errorHandler, false);
+	  else if (document.msFullscreenEnabled) element.addEventListener('msfullscreenerror', errorHandler, false);
   }
 };
 

--- a/src/base.js
+++ b/src/base.js
@@ -330,17 +330,27 @@ VRDisplay.prototype.addFullscreenListeners_ = function(element, changeHandler, e
   this.fullscreenErrorHandler_ = errorHandler;
 
   if (changeHandler) {
-    if (document.fullscreenEnabled) element.addEventListener('fullscreenchange', changeHandler, false);
-	  else if (document.webkitFullscreenEnabled) element.addEventListener('webkitfullscreenchange', changeHandler, false);
-	  else if (document.mozFullscreenEnabled) document.addEventListener('mozfullscreenchange', changeHandler, false);
-	  else if (document.msFullscreenEnabled) element.addEventListener('msfullscreenchange', changeHandler, false);
+    if (document.fullscreenEnabled) {
+      element.addEventListener('fullscreenchange', changeHandler, false);
+    } else if (document.webkitFullscreenEnabled) {
+      element.addEventListener('webkitfullscreenchange', changeHandler, false);
+    } else if (document.mozFullScreenEnabled) {
+      document.addEventListener('mozfullscreenchange', changeHandler, false);
+    } else if (document.msFullscreenEnabled) {
+      element.addEventListener('msfullscreenchange', changeHandler, false);
+    }
   }
 
   if (errorHandler) {
-    if (document.fullscreenEnabled) element.addEventListener('fullscreenerror', errorHandler, false);
-	  else if (document.webkitFullscreenEnabled) element.addEventListener('webkitfullscreenerror', errorHandler, false);
-	  else if (document.mozFullscreenEnabled) document.addEventListener('mozfullscreenerror', errorHandler, false);
-	  else if (document.msFullscreenEnabled) element.addEventListener('msfullscreenerror', errorHandler, false);
+    if (document.fullscreenEnabled) {
+      element.addEventListener('fullscreenerror', errorHandler, false);
+    } else if (document.webkitFullscreenEnabled) {
+      element.addEventListener('webkitfullscreenerror', errorHandler, false);
+    } else if (document.mozFullScreenEnabled) {
+      document.addEventListener('mozfullscreenerror', errorHandler, false);
+    } else if (document.msFullscreenEnabled) {
+      element.addEventListener('msfullscreenerror', errorHandler, false);
+    }
   }
 };
 

--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -149,6 +149,11 @@ CardboardVRDisplay.prototype.beginPresent_ = function() {
       e.preventDefault();
     }.bind(this), function(e) {
       // Back clicked.
+
+      // In case of a custom calllback defined by the user, trigger it
+      if (typeof WebVRConfig.BACKACTION_CALLBACK === 'function') {
+        WebVRConfig.BACKACTION_CALLBACK();
+      }
       this.exitPresent();
       e.stopPropagation();
       e.preventDefault();

--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -243,6 +243,12 @@ CardboardVRDisplay.prototype.onResize_ = function(e) {
     // hide the URL bar unless content is bigger than the screen.
     // This will not be visible as long as the container element (e.g. body)
     // is set to 'overflow: hidden'.
+    var padding;
+    if (Util.isIOS()) {
+      padding = '0 10px 10px 0';
+    } else {
+      padding = '0';
+    }
     var cssProperties = [
       'position: absolute',
       'top: 0',
@@ -251,7 +257,7 @@ CardboardVRDisplay.prototype.onResize_ = function(e) {
       'height: ' + Math.min(screen.height, screen.width) + 'px',
       'border: 0',
       'margin: 0',
-      'padding: 0 10px 10px 0',
+      'padding:' + padding,
     ];
     gl.canvas.setAttribute('style', cssProperties.join('; ') + ';');
 

--- a/src/cardboard-vr-display.js
+++ b/src/cardboard-vr-display.js
@@ -150,11 +150,13 @@ CardboardVRDisplay.prototype.beginPresent_ = function() {
     }.bind(this), function(e) {
       // Back clicked.
 
-      // In case of a custom calllback defined by the user, trigger it
-      if (typeof WebVRConfig.BACKACTION_CALLBACK === 'function') {
-        WebVRConfig.BACKACTION_CALLBACK();
-      }
-      this.exitPresent();
+      this.exitPresent().then(function () {
+        // In case of a custom calllback defined by the user, trigger it
+        if (typeof WebVRConfig.BACKACTION_CALLBACK === 'function') {
+          WebVRConfig.BACKACTION_CALLBACK();
+        }
+      });
+
       e.stopPropagation();
       e.preventDefault();
     }.bind(this));

--- a/src/device-info.js
+++ b/src/device-info.js
@@ -82,6 +82,13 @@ var DEFAULT_RIGHT_CENTER = {x: 0.5, y: 0.5};
  * params were found.
  */
 function DeviceInfo(deviceParams) {
+  if (WebVRConfig.ADDITIONAL_VIEWERS instanceof Array) {
+    var newViewer;
+    for (var i = 0; i < WebVRConfig.ADDITIONAL_VIEWERS.length; i++) {
+      newViewer = WebVRConfig.ADDITIONAL_VIEWERS[i];
+      Viewers[newViewer.id] = new CardboardViewer(newViewer);
+    }
+  }
   this.viewer = Viewers.CardboardV2;
   this.updateDeviceParams(deviceParams);
   this.distortion = new Distortion(this.viewer.distortionCoefficients);


### PR DESCRIPTION
Without doing this, it can happen that the handlers are called via the 'fullscreenchange' and 'webkitfullscreenchange' event when using the 'Fullscreen-API-Polyfill' (https://github.com/neovov/Fullscreen-API-Polyfill). So it is best to only listen to one of the events, otherwise the handler may be called several times which lead to nothing being presented.