### PR TITLE
Implement navigator.vrEnabled

### DIFF
--- a/build/webvr-polyfill.js
+++ b/build/webvr-polyfill.js
@@ -5621,6 +5621,18 @@ WebVRPolyfill.prototype.enablePolyfill = function() {
 
   // Provide the VRDisplay object.
   window.VRDisplay = VRDisplay;
+
+  // Provide vrEnabled
+  var that = this;
+  Object.defineProperty(navigator, 'vrEnabled', {
+    get: function () {
+      return that.isCardboardCompatible() &&
+        (document.fullscreenEnabled ||
+          document.mozFullScreenEnabled ||
+          document.webkitFullscreenEnabled ||
+          false);
+    }
+  });
 };
 
 WebVRPolyfill.prototype.enableDeprecatedPolyfill = function() {

--- a/build/webvr-polyfill.js
+++ b/build/webvr-polyfill.js
@@ -5622,11 +5622,11 @@ WebVRPolyfill.prototype.enablePolyfill = function() {
   // Provide the VRDisplay object.
   window.VRDisplay = VRDisplay;
 
-  // Provide vrEnabled
-  var that = this;
+  // Provide navigator.vrEnabled.
+  var self = this;
   Object.defineProperty(navigator, 'vrEnabled', {
     get: function () {
-      return that.isCardboardCompatible() &&
+      return self.isCardboardCompatible() &&
         (document.fullscreenEnabled ||
           document.mozFullScreenEnabled ||
           document.webkitFullscreenEnabled ||

--- a/src/webvr-polyfill.js
+++ b/src/webvr-polyfill.js
@@ -97,10 +97,10 @@ WebVRPolyfill.prototype.enablePolyfill = function() {
   window.VRDisplay = VRDisplay;
 
   // Provide navigator.vrEnabled.
-  var that = this;
+  var self = this;
   Object.defineProperty(navigator, 'vrEnabled', {
     get: function () {
-      return that.isCardboardCompatible() &&
+      return self.isCardboardCompatible() &&
         (document.fullscreenEnabled ||
           document.mozFullScreenEnabled ||
           document.webkitFullscreenEnabled ||

--- a/src/webvr-polyfill.js
+++ b/src/webvr-polyfill.js
@@ -96,7 +96,7 @@ WebVRPolyfill.prototype.enablePolyfill = function() {
   // Provide the VRDisplay object.
   window.VRDisplay = VRDisplay;
 
-  // Provide vrEnabled.
+  // Provide navigator.vrEnabled.
   var that = this;
   Object.defineProperty(navigator, 'vrEnabled', {
     get: function () {

--- a/src/webvr-polyfill.js
+++ b/src/webvr-polyfill.js
@@ -95,6 +95,18 @@ WebVRPolyfill.prototype.enablePolyfill = function() {
 
   // Provide the VRDisplay object.
   window.VRDisplay = VRDisplay;
+
+  // Provide vrEnabled
+  var that = this;
+  Object.defineProperty(navigator, 'vrEnabled', {
+    get: function () {
+      return that.isCardboardCompatible() &&
+        (document.fullscreenEnabled ||
+          document.mozFullScreenEnabled ||
+          document.webkitFullscreenEnabled ||
+          false);
+    }
+  });
 };
 
 WebVRPolyfill.prototype.enableDeprecatedPolyfill = function() {

--- a/src/webvr-polyfill.js
+++ b/src/webvr-polyfill.js
@@ -96,7 +96,7 @@ WebVRPolyfill.prototype.enablePolyfill = function() {
   // Provide the VRDisplay object.
   window.VRDisplay = VRDisplay;
 
-  // Provide vrEnabled
+  // Provide vrEnabled.
   var that = this;
   Object.defineProperty(navigator, 'vrEnabled', {
     get: function () {


### PR DESCRIPTION
Refer to the [spec](https://w3c.github.io/webvr/#navigator-vrenabled-attribute)

This will be necessary when running a webvr page inside an iframe that may or may not have the appropriate permissions to access webvr devices. The iframe needs to detect when it does not have permission so it can pop out into a new window or otherwise notify the user that VR is not supported.

Because of the nature of the polyfill, this behaves a little bit differently from the native implementation. Natively, `navigator.vrEnabled` requires an iframe to have the `allowvr` attribute set, but since the polyfill uses full screen instead, in this case it will require the `allowfullscreen` attribute (and/or prefixed alternatives for older browser versions).

Note: Currently, neither Firefox nor Chromium implements this property natively, but presumably they will before release, since it's in the spec.